### PR TITLE
feat: Add cache header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ A GET request `/iiif/v3/sample_image.jpg/info.json` would then cause the plug to
 
 For the complete list of plug options have a look at the module documentation.
 
+### Cache Headers
+
+The plug supports setting cache control headers on image responses to improve CDN and browser caching:
+
+```elixir
+# Static cache control for all images
+forward("/iiif/v3", IIIFImagePlug.V3, %{
+  identifier_to_path_callback: &ImageStore.identifier_to_path/1,
+  cache_control: "public, max-age=31536000, immutable"
+})
+
+# Dynamic cache control based on identifier
+forward("/iiif/v3", IIIFImagePlug.V3, %{
+  identifier_to_path_callback: &ImageStore.identifier_to_path/1,
+  identifier_to_cache_control_callback: fn
+    "private/" <> _ -> "private, max-age=3600"
+    _ -> "public, max-age=86400"
+  end
+})
+```
+
+Cache headers are only set on successful image responses (not on info.json, redirects, or errors).
+
 ### CORS 
 
 For your service to fully implement the API specification, you need to properly configure Cross-Origin Resource Sharing (CORS). This has to be done outside the context of this plug, one option could be to use the

--- a/lib/iiif_image_plug/v3.ex
+++ b/lib/iiif_image_plug/v3.ex
@@ -205,7 +205,7 @@ defmodule IIIFImagePlug.V3 do
       {%Image{} = image, format} ->
         cond do
           format not in @streamable and temp_dir == :buffer ->
-            send_buffered(conn, image, format)
+            send_buffered(conn, image, format, identifier, options)
 
           format not in @streamable ->
             prefix = :crypto.strong_rand_bytes(8) |> Base.url_encode64() |> binary_part(0, 8)
@@ -213,10 +213,10 @@ defmodule IIIFImagePlug.V3 do
             file_name =
               "#{prefix}_#{quality_and_format}"
 
-            send_temporary_file(conn, image, Path.join(temp_dir, file_name))
+            send_temporary_file(conn, image, Path.join(temp_dir, file_name), identifier, options)
 
           true ->
-            send_stream(conn, image, format)
+            send_stream(conn, image, format, identifier, options)
         end
 
       {:error, :no_file} ->
@@ -256,12 +256,15 @@ defmodule IIIFImagePlug.V3 do
     )
   end
 
-  defp send_buffered(conn, %Image{} = image, format) do
+  defp send_buffered(conn, %Image{} = image, format, identifier, options) do
     {:ok, buffer} = Image.write_to_buffer(image, ".#{format}")
-    send_resp(conn, 200, buffer)
+
+    conn
+    |> maybe_put_cache_headers(identifier, options)
+    |> send_resp(200, buffer)
   end
 
-  defp send_temporary_file(conn, %Image{} = image, file_path) do
+  defp send_temporary_file(conn, %Image{} = image, file_path, identifier, options) do
     parent = self()
 
     spawn(fn ->
@@ -274,13 +277,19 @@ defmodule IIIFImagePlug.V3 do
     end)
 
     Image.write_to_file(image, file_path)
-    send_file(conn, 200, file_path)
+
+    conn
+    |> maybe_put_cache_headers(identifier, options)
+    |> send_file(200, file_path)
   end
 
-  defp send_stream(conn, %Image{} = image, format) do
+  defp send_stream(conn, %Image{} = image, format, identifier, options) do
     stream = Image.write_to_stream(image, ".#{format}")
 
-    conn = send_chunked(conn, 200)
+    conn =
+      conn
+      |> maybe_put_cache_headers(identifier, options)
+      |> send_chunked(200)
 
     Enum.reduce_while(stream, conn, fn data, conn ->
       case chunk(conn, data) do
@@ -442,6 +451,32 @@ defmodule IIIFImagePlug.V3 do
       Map.put(info, :sizes, sizes)
     else
       info
+    end
+  end
+
+  defp maybe_put_cache_headers(conn, identifier, %Options{
+         cache_control: cache_control,
+         identifier_to_cache_control_callback: callback
+       }) do
+    cache_header_value =
+      cond do
+        # Callback takes precedence
+        is_function(callback, 1) ->
+          callback.(identifier)
+
+        # Static cache control
+        is_binary(cache_control) ->
+          cache_control
+
+        # No cache control configured
+        true ->
+          nil
+      end
+
+    if cache_header_value do
+      put_resp_header(conn, "cache-control", cache_header_value)
+    else
+      conn
     end
   end
 end

--- a/lib/iiif_image_plug/v3/options.ex
+++ b/lib/iiif_image_plug/v3/options.ex
@@ -38,6 +38,19 @@ defmodule IIIFImagePlug.V3.Options do
   If you want to forgo this file creation, you can set this option to `:buffer` instead of a file path. This will configure
   the plug to write the complete image to memory instead of disk - which is faster but also may cause memory issues if
   very large images are requested.
+
+  ### `:cache_control` (optional)
+
+  Sets the Cache-Control header for all image responses. For example:
+  - `"public, max-age=31536000, immutable"` for long-term caching
+  - `"private, max-age=3600"` for short-term private caching
+  - `nil` (default) to not set any cache headers
+
+  ### `:identifier_to_cache_control_callback` (optional)
+
+  An arity 1 callback function that returns a Cache-Control header value for a given identifier.
+  This allows dynamic cache control based on the image being served. If both this and `:cache_control`
+  are provided, this callback takes precedence.
   """
 
   defstruct max_width: 10000,
@@ -45,7 +58,9 @@ defmodule IIIFImagePlug.V3.Options do
             max_area: 10000 * 10000,
             preferred_formats: [:jpg],
             extra_formats: [:webp, :png],
-            temp_dir: Path.join(System.tmp_dir!(), "iiif_image_plug")
+            temp_dir: Path.join(System.tmp_dir!(), "iiif_image_plug"),
+            cache_control: nil,
+            identifier_to_cache_control_callback: nil
 
   @type t :: %__MODULE__{
           max_width: integer(),
@@ -53,6 +68,8 @@ defmodule IIIFImagePlug.V3.Options do
           max_area: integer(),
           preferred_formats: list(),
           extra_formats: list(),
-          temp_dir: String.t() | atom()
+          temp_dir: String.t() | atom(),
+          cache_control: String.t() | nil,
+          identifier_to_cache_control_callback: (String.t() -> String.t() | nil) | nil
         }
 end

--- a/test/cache_headers_test.exs
+++ b/test/cache_headers_test.exs
@@ -1,0 +1,289 @@
+defmodule IIIFImagePlug.V3.CacheHeadersTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+  import Plug.Conn, only: [get_resp_header: 2]
+
+  alias IIIFImagePlug.V3.Options
+
+  @sample_jpg "bentheim_mill.jpg"
+
+  # Create test plugs with different cache configurations
+  defmodule StaticCachePlug do
+    use IIIFImagePlug.V3
+
+    @impl true
+    def identifier_to_path(identifier) do
+      {:ok, "test/images/#{identifier}"}
+    end
+
+    @impl true
+    def host(), do: "localhost"
+
+    @impl true
+    def port(), do: 4001
+  end
+
+  defmodule DynamicCachePlug do
+    use IIIFImagePlug.V3
+
+    @impl true
+    def identifier_to_path(identifier) do
+      # Map test identifiers to real test images
+      case identifier do
+        "public_image.jpg" -> {:ok, "test/images/bentheim_mill.jpg"}
+        "private_image.jpg" -> {:ok, "test/images/bentheim_mill.jpg"}
+        "override_image.jpg" -> {:ok, "test/images/bentheim_mill.jpg"}
+        _ -> {:ok, "test/images/#{identifier}"}
+      end
+    end
+
+    @impl true
+    def host(), do: "localhost"
+
+    @impl true
+    def port(), do: 4001
+  end
+
+  describe "static cache control" do
+    test "sets cache-control header when configured" do
+      opts = %Options{
+        cache_control: "public, max-age=31536000, immutable"
+      }
+
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/0/default.jpg")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+
+    test "does not set cache-control header when not configured" do
+      opts = %Options{}
+
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/0/default.jpg")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      # When no cache control is configured, the IIIF plug should not set any cache headers
+      # (though the test environment might set its own defaults)
+      cache_control_headers = get_resp_header(conn, "cache-control")
+      # Just ensure we didn't set any long-term caching headers
+      refute Enum.any?(cache_control_headers, &String.contains?(&1, "max-age=31536000"))
+    end
+  end
+
+  describe "dynamic cache control via callback" do
+    setup do
+      callback = fn
+        "public_image.jpg" -> "public, max-age=86400"
+        "private_image.jpg" -> "private, max-age=3600"
+        _ -> nil
+      end
+
+      {:ok, opts: %Options{identifier_to_cache_control_callback: callback}}
+    end
+
+    test "sets cache-control header based on identifier callback", %{opts: opts} do
+      conn =
+        conn(:get, "/public_image.jpg/full/max/0/default.jpg")
+        |> DynamicCachePlug.call(DynamicCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=86400"]
+    end
+
+    test "sets different cache-control for private images", %{opts: opts} do
+      conn =
+        conn(:get, "/private_image.jpg/full/max/0/default.jpg")
+        |> DynamicCachePlug.call(DynamicCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["private, max-age=3600"]
+    end
+
+    test "callback returning nil results in no cache header", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/0/default.jpg")
+        |> DynamicCachePlug.call(DynamicCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      # When callback returns nil, no custom cache headers should be set
+      cache_control_headers = get_resp_header(conn, "cache-control")
+      # Ensure none of our custom cache headers are present
+      refute "public, max-age=86400" in cache_control_headers
+      refute "private, max-age=3600" in cache_control_headers
+    end
+  end
+
+  describe "callback takes precedence over static config" do
+    test "uses callback value when both are configured" do
+      callback = fn
+        "override_image.jpg" -> "no-cache"
+        _ -> nil
+      end
+
+      opts = %Options{
+        cache_control: "public, max-age=31536000",
+        identifier_to_cache_control_callback: callback
+      }
+
+      conn =
+        conn(:get, "/override_image.jpg/full/max/0/default.jpg")
+        |> DynamicCachePlug.call(DynamicCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["no-cache"]
+    end
+  end
+
+  describe "cache headers work with different output formats" do
+    setup do
+      {:ok, opts: %Options{cache_control: "public, max-age=31536000, immutable"}}
+    end
+
+    test "sets cache headers for JPEG output", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/0/default.jpg")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+
+    test "sets cache headers for PNG output", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/0/default.png")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+
+    test "sets cache headers for WebP output", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/0/default.webp")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+
+    test "sets cache headers for TIFF output (buffered)" do
+      opts = %Options{
+        cache_control: "public, max-age=31536000, immutable",
+        temp_dir: :buffer,
+        extra_formats: [:tif]
+      }
+
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/0/default.tif")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+  end
+
+  describe "cache headers with different image operations" do
+    setup do
+      {:ok, opts: %Options{cache_control: "public, max-age=31536000, immutable"}}
+    end
+
+    test "sets cache headers for region extraction", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/100,100,200,200/max/0/default.jpg")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+
+    test "sets cache headers for size operations", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/200,200/0/default.jpg")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+
+    test "sets cache headers for rotation operations", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/90/default.jpg")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+
+    test "sets cache headers for quality operations", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/full/max/0/gray.jpg")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    end
+  end
+
+  describe "no cache headers for non-image responses" do
+    setup do
+      {:ok, opts: %Options{cache_control: "public, max-age=31536000, immutable"}}
+    end
+
+    test "does not set cache headers for info.json", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}/info.json")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 200
+
+      # The test plug seems to set default headers, we just care that our custom headers aren't set
+      cache_control_headers = get_resp_header(conn, "cache-control")
+      refute "public, max-age=31536000, immutable" in cache_control_headers
+    end
+
+    test "does not set cache headers for redirects", %{opts: opts} do
+      conn =
+        conn(:get, "/#{@sample_jpg}")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :set]
+      assert conn.status == 302
+      # Redirects should not have our custom cache headers
+      cache_control_headers = get_resp_header(conn, "cache-control")
+      refute "public, max-age=31536000, immutable" in cache_control_headers
+    end
+
+    test "does not set cache headers for errors", %{opts: opts} do
+      conn =
+        conn(:get, "/nonexistent.jpg/full/max/0/default.jpg")
+        |> StaticCachePlug.call(StaticCachePlug.init(opts))
+
+      assert conn.state in [:sent, :chunked]
+      assert conn.status == 404
+
+      # The test plug seems to set default headers, we just care that our custom headers aren't set
+      cache_control_headers = get_resp_header(conn, "cache-control")
+      refute "public, max-age=31536000, immutable" in cache_control_headers
+    end
+  end
+end


### PR DESCRIPTION
Closes #9

This PR introduces support for  headers on IIIF image responses, allowing for better CDN and browser caching.

### Changes

- Adds a  option to  for a static cache header value.
- Adds an  option for dynamically determining the cache header based on the image identifier.
- Implements the cache header logic for all image response types (buffered, file, and stream).
- Includes a new test suite () with comprehensive coverage for the new functionality.
- Updates the  to document the new options with usage examples.